### PR TITLE
Fix typos and syntax error 

### DIFF
--- a/Day02/ReadMe.md
+++ b/Day02/ReadMe.md
@@ -74,7 +74,7 @@ contract GlobalVariables {
 
 - ```view``` is like pure, it is a read-only function. Unlike pure functions, view functions can read data from state variables and global variables.
 - ```msg.sender``` is a global variable that stores the addresss that calls this function, its datatype is address.
-- ```block.timestamp``` stores the unix timestamp of when this fucntion was called, its datatype is unit.
+- ```block.timestamp``` stores the unix timestamp of when this fucntion was called, its datatype is uint.
 - ```block.number``` stores the current [block number](https://www.youtube.com/watch?v=_160oMzblY8&t=2s), its datatype is uint.
 - ```sender, timestamp, blockNum``` are the defined Global Variables.
 

--- a/Day03/ReadMe.md
+++ b/Day03/ReadMe.md
@@ -60,9 +60,8 @@ contract IfElse {
    // if(x < 10) {
    //   return 1;
    // } return 2;
+   return _x < 10 ? 1 : 2;
   }
-  
-  return _x < 10 ? 1 : 2; 
 
 }
 

--- a/Day05/ReadMe.md
+++ b/Day05/ReadMe.md
@@ -20,7 +20,7 @@ contract Constructor {
 ```
 - Here we have a state variable type address named ```owner``` and a uint named ```x```.
 - We are using ```constructor``` to initialize owner and state variable uint x.
-- We define by using the keyword ```constructor``` and inside the parathesis we can put in the inputs, here it is ```_x```.
+- We define by using the keyword ```constructor``` and inside the parenthesis we can put in the inputs, here it is ```_x```.
 - Inside the curly braces of a constructor, we can write any code just like a regular function.
 - We initailize the state variable owner to the address that deployed this contract. We do that by typing ```owner = msg.sender```.
 - ```msg.sender``` will be the account that deployed this contract, here we are saying that, set the owner to the account that deployed this contract.
@@ -104,9 +104,9 @@ contract FunctionOutput {
 ```
 
 - the function ```returnMany()``` returns multiple outputs. There is no inputs, we use ```public``` instead of ```external``` because we will be using this function in another function inside this contract. This function is read only so we are using ```pure```.
-- the ```returns( )``` is how we declare this function will return multiple outputs. Inside the paranthesis we declare the types of outputs. Inside the function body we will match the return type.
+- the ```returns( )``` is how we declare this function will return multiple outputs. Inside the parenthesis we declare the types of outputs. Inside the function body we will match the return type.
 - We can also name the outputs, by declaring the name after the data type ```returns(uint x, bool b)```. When we have named outputs we can implicitly return the outputs. We can assign the value to the named output. Writing functions like this will save us a little bit of gas. This is because there is one less copying to do.
-- Destructring assignments is how we capture the outputs in a function. Inside the ```destrcturingAssignment()``` we call the ```returnMany()``` function. To capture the output of returnMany() as a varaible for the destructuringAssignment() function, we use paranthesis and inside the paranthesis we declare the variables that we want to capture ```(uint x, bool b) = returnMany();```.
+- Destructring assignments is how we capture the outputs in a function. Inside the ```destrcturingAssignment()``` we call the ```returnMany()``` function. To capture the output of returnMany() as a varaible for the destructuringAssignment() function, we use parenthesis and inside the parenthesis we declare the variables that we want to capture ```(uint x, bool b) = returnMany();```.
 - If we only need the second output, we can omit the first variable like this ```(, bool _b) = returnMany();```, name _b is used to avoid the name conflict.
 
 <div align=center><a href="https://github.com/0xronin/30-days-SmartContractProgrammer/tree/main/Day04"><< Day 4

--- a/Day06/ReadMe.md
+++ b/Day06/ReadMe.md
@@ -16,7 +16,7 @@ contract Array{
     uint x = nums[1]; // x = 2
     nums[2] = 777 // [1,2,777,4]
     delete nums[1]; // [1,0,777,4]
-    nums.pop(); // [1.0,777]
+    nums.pop(); // [1,0,777]
     uint len = nums.length; // 3
     
     // create array in memory
@@ -47,7 +47,7 @@ contract Array{
 
 ### Array Remove An Element By Shifting
 
-When we use th ```delete``` to clear element from an array, it does not removes the element but only resets it to it's default value.
+When we use the ```delete``` to clear element from an array, it does not removes the element but only resets it to it's default value.
 The basic idea of this method is to shift all the elements to the left and pop the last element.
 
 ```solidity
@@ -98,7 +98,7 @@ contract ArrayShift {
 - we check our algo by running the function ```test()```
 
 ### Array Remove An Element By Replacing Last
-Shifting is not an gas-efficient way to remove an element from an array, the idea here is to shuffle the elements by replacing the element we want to remove with the last element. However the order of the elements in the array is not reserved when using this menthod.
+Shifting is not an gas-efficient way to remove an element from an array, the idea here is to shuffle the elements by replacing the element we want to remove with the last element. However the order of the elements in the array is not reserved when using this method.
 
 ```solidity
 contract ArrayReplaceLast {

--- a/Day06/ReadMe.md
+++ b/Day06/ReadMe.md
@@ -62,9 +62,9 @@ contract ArrayShift {
     delete arr[1]; // [1,0,3]
   }
   
-  // [1,2,3] ... remove 2 --> [1,3,3] --> [1,3]
-  // [1,2,3,4,5,6] ... remove 3 --> [1,2,4,5,6,6] --> [1,2,4,5,6]
-  // [1] ... remove 1 --> [1] --> []
+  // [1,2,3] ... remove(1) --> [1,3,3] --> [1,3]
+  // [1,2,3,4,5,6] ... remove(2) --> [1,2,4,5,6,6] --> [1,2,4,5,6]
+  // [1] ... remove(0) --> [1] --> []
   
   function remove(uint _index) public {
     require(_index < arr.length, "Index out of bound");

--- a/Day07/ReadMe.md
+++ b/Day07/ReadMe.md
@@ -24,7 +24,7 @@ contract Mapping {
 }
 ```
 
-- we declare a mapping called ```balances``` by using the keyword ```mapping``` followed by the paranthesis, inside the paranthesis we define the key type and the value type. ```mapping(address => uint) public balances``` this mapping represents balance of each address. With the address we can lookup the balance of the address.
+- we declare a mapping called ```balances``` by using the keyword ```mapping``` followed by the parenthesis, inside the parenthesis we define the key type and the value type. ```mapping(address => uint) public balances``` this mapping represents balance of each address. With the address we can lookup the balance of the address.
 - we can create nested mapping, the mapping in the example is called ```isFriend``` which goes from address to another mapping which goes from address to boolean ```mapping (address => mapping(address => bool)) public isFriend```
 - we can set value to a certain key in a mapping by ```balances[msg.sender] = 123```
 - we can get the value from a mapping by ```uint bal = balances[msg.sender]```
@@ -126,8 +126,8 @@ contract Structs {
 - we have created a struct called ```Car``` and inside we put model, year and owner.
 - we can use struct as a state-variable by calling ```Car public car```, we can create an array of structs by typing ```Car[] public cars```, and we can define a mapping from owner to cars by typing ```mapping (address => Car[]) public carsByOwner```.
 - Initializing: There are three ways to initialize a struct
-    - the first is similar to how we execute a function, by putting all the parameters inside the paranthesis ```Car memory toyota = Car("Toyota", 1990, msg.sender)``` we create a variable with name ```toyota``` of type ```Car```struct inside ```memory``` meaning this variable will only exist while this function is called. The parameters have to be in the order they are declared initially.
-    - another way is to pass key-value pairs inside the paranthesis ```Car memory lambo = Car({year: 1980, model: "Lamborghini", owner: msg.sender})```. The order does not matter.
+    - the first is similar to how we execute a function, by putting all the parameters inside the parenthesis ```Car memory toyota = Car("Toyota", 1990, msg.sender)``` we create a variable with name ```toyota``` of type ```Car```struct inside ```memory``` meaning this variable will only exist while this function is called. The parameters have to be in the order they are declared initially.
+    - another way is to pass key-value pairs inside the parenthesis ```Car memory lambo = Car({year: 1980, model: "Lamborghini", owner: msg.sender})```. The order does not matter.
     - third way to initialize a struct is to just define it, and the struct will have defalut values ```Car memory tesla```. We can push data in the tesla Car struct ```tesla.model = "Tesla"; tesla.year = 2010; tesla.owner = msg.sender;```
 - after the function is finished executing these structs will be gone because of ```memory```, so we need to put these structs in a state variable so that we are able to get the structs from the smart contract by pushing the structs into the car array ```cars.push(toyota); cars.push(lambo); cars.push(tesla);```.
 - We can also create a struct wihtout having to initialize it as memory and save it as a state-variable, we can directly create a struct and push it immediately into the array by doing the following ```cars.push(Car("Ferrari", 2020, msg.sender))```.

--- a/Day09/ReadMe.md
+++ b/Day09/ReadMe.md
@@ -10,9 +10,9 @@ Events allow you to write data on the blockchain, this data can later not be ret
 ```solidity 
 contract Event {
     event Log(string message, uint val);
-    event IndexedLog(adress indexed sender, uint val);
+    event IndexedLog(address indexed sender, uint val);
     
-    function example() exteranal {
+    function example() external {
         emit Log("foo", 1234);
         emit IndexedLog(msg.sender, 789);
     }
@@ -259,7 +259,7 @@ contract F is E {
 contract G is E {
     function foo() public virtual override {
         emit Log("G.foo");
-        E.Foo();
+        E.foo();
     }
     function bar() public virtual override {
         emit Log("G.bar");

--- a/Day10/ReadMe.md
+++ b/Day10/ReadMe.md
@@ -152,7 +152,7 @@ contract Fallback {
 ### 3 Ways to Send Ether
 There are 3 ways in Solidity to send ether
 - transfer - 2300 gas, reverts
-- send - 2300 gas, returs bool
+- send - 2300 gas, returns bool
 - call - all gas, returns bool and data
 
 To be able to send ether from a contract, it must be able to first receive ether. One way is by having a ```payable constructor```, another is by having a ```payable fallback```. Having only the receive fuction means this contract will be able to receive ether, and if a function that is not present in this contract is called it will revert.

--- a/Day11/ReadMe.md
+++ b/Day11/ReadMe.md
@@ -4,7 +4,7 @@ Here in the example below we are going to call functions from the ```TestContrac
 For the inputs in the function, we pass in the address of the contract we are calling, along with other input if present.
 
 There are several ways to call other contracts
-1. The first way is to initialize the contract, we do that by typing the contract name and pass in the address of the contract in the input to initialize it. ```TestContract(_test)``` and the function we want to call in writter after a period ```.``` like ```TestContract(_test).setX(_x)```, this here will call the TestContract deployed at the address _test and it's going to call the function setX with the input _x.
+1. The first way is to initialize the contract, we do that by typing the contract name and pass in the address of the contract in the input to initialize it. ```TestContract(_test)``` and the function we want to call in write after a period ```.``` like ```TestContract(_test).setX(_x)```, this here will call the TestContract deployed at the address _test and it's going to call the function setX with the input _x.
 2. Another way is to pass in the contract as a type directly replacing the address keyword, for example ```setX(TestContract _test, uint _x)```
 
 
@@ -153,15 +153,15 @@ contract Call {
     // since the TestCall contract has a fallback function so it will be executed and emit the Log() event
     
     function callDoesNotExist(address _test) external {
-        (bool success, ) = _test.call(abi.ecodeWithSignature("doesNotExist()"));
+        (bool success, ) = _test.call(abi.encodeWithSignature("doesNotExist()"));
         require(success, "falied to call");
     }
     
 }
 ```
 - first we are going to call the function ```foo()```, so we create a function ```callFoo()``` in the Call contract, the input of the callFoo() function will be the addresss of the deployed TestCall contract called ```_test```. 
-- we use the low-level call function, by typing _test.call(), inside the paranthesis we need to ecode the function ```abi.ecodeWithSignature()``` we are calling followed by the inputs we are going to be passing
-- the first input for ```abi.ecodeWithSignature()``` will be the function we going to be calling which is ```foo()``` this function takes in a string and uint256 as input. ```Be careful to not put any spaces between the input inside the called function```.
+- we use the low-level call function, by typing _test.call(), inside the parenthesis we need to ecode the function ```abi.encodeWithSignature()``` we are calling followed by the inputs we are going to be passing
+- the first input for ```abi.encodeWithSignature()``` will be the function we going to be calling which is ```foo()``` this function takes in a string and uint256 as input. ```Be careful to not put any spaces between the input inside the called function```.
 - next we need to pass the inputs which is type string and type uint respectively. 
 - when we use call it is going to return two outputs, the first output will be a boolean that tells whether the call was successful or not, and the second output will be any output that was returned from calling the function foo(), and it will be in bytes.
 - when we are using ```call``` to call functions, we can specify the gas we are going to be sending and also the amount of ether we are going to be sending. ```call{value: 111 gas: 5000}```

--- a/Day12/ReadMe.md
+++ b/Day12/ReadMe.md
@@ -56,13 +56,13 @@ contract DelegateCall {
     // require(success, "call failed");
     
     (bool success, bytes memory data) = _test.delegatecall(
-    abi.ecodeWithSelector(TestDelegateCall.setVars.selector, _num)
+    abi.encodeWithSelector(TestDelegateCall.setVars.selector, _num)
     );
     require(success, "delegatecall failed");
   }
 }
 ```
-- the state variables of the contract that is called ```TestDelegateCall`` will not be updated, instead the state variables of the contract that called gets updates. Here it will be ```DelegateCall`` contract's variables.
+- the state variables of the contract that is called ```TestDelegateCall``` will not be updated, instead the state variables of the contract that called gets updates. Here it will be ```DelegateCall``` contract's variables.
 - we can update the logic of the contract that gets called, even though we cannot change any of the code in the contract that makes the delegatecall.
 - please keep in mind, when using the delegatecall to update the logic, all of the state variables have to be the same and must be in the same order.
 
@@ -94,7 +94,7 @@ contract AccountFactory {
 }
 ```
 - here we are deploying contract ```Account``` from another contract ```AccountFactory``` using the function ```createAccount```, the input of this function will be address ```_owner``` which is passed in as the constructor input of the ```Account``` contract at the time of deployment.
-- to deploy another contract from within a contract we use the keyword ```new``` followed by the name of the contract we are deploying. Inside the paranthesis we pass in the inputs to pass to the constructor.
+- to deploy another contract from within a contract we use the keyword ```new``` followed by the name of the contract we are deploying. Inside the parenthesis we pass in the inputs to pass to the constructor.
 - to assign this newly deployed Account contract as a variable, here we type ```Account account = new Acc...```.
 - we create an array of accounts to store the contracts that we deploy, ```Account[] public accounts```.
 - after we deploy the contract, we push the account in the Account[] array by typing ```accounts.push(account)```.


### PR DESCRIPTION
This PR fixes typos and syntax error in example code.

Thank you for your nice SmartContract text book!